### PR TITLE
Test paas-app-charmer changes in discourse-gateway

### DIFF
--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -77,10 +77,6 @@ jobs:
           commit_sha: ${{  steps.prepare-stage.outputs.commit_sha }}
           charm_dir:  ${{ matrix.charm-dir }}
 
-      - name: Tmate debugging session (gh-hosted)
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 30
-
       - name: Check creation
         run: |
           echo '${{ steps.import.outputs.pr_link }}'
@@ -108,6 +104,11 @@ jobs:
           
           COMMIT_SHA=$(git log | head -n 1 | sed -En "s/commit\ //p")
           echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
+
+
+      - name: Tmate debugging session (gh-hosted)
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 30
 
       - name: Release Pipeline Documentation
         id: release-import

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -61,7 +61,7 @@ jobs:
               # Create charmcraft.yaml file
               echo "name: $(echo ${{ github.repository }} | sed 's:.*/::')-test" > "${{ matrix.charm-dir }}"/charmcraft.yaml
               echo "links:" >> "${{ matrix.charm-dir }}"/charmcraft.yaml
-              echo "  documentation: https://discourse.charmhub.io/t/netbox-documentation-overview/13564" >> "${{ matrix.charm-dir }}"/charmcraft.yaml
+              echo "  documentation: https://discourse.charmhub.io/t/charmed-mongodb-k8s-documentation/9731" >> "${{ matrix.charm-dir }}"/charmcraft.yaml
           fi
 
       - name: Import Documentation

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -42,12 +42,10 @@ jobs:
         id: prepare-stage
         run: |
           PYTHONPATH=$(pwd) python3 tests/e2e/migrate.py --charm-dir "./${{ matrix.charm-dir }}" --action prepare --github-token  ${{ secrets.GITHUB_TOKEN }} '${{ steps.configuration.outputs.discourse }}'
-          git branch
-          git rev-parse HEAD
-
+          
           if [ ! -d "./${{ matrix.charm-dir }}" ]; then
+              # For this case, charm-dir not the base directory, use charmcraft.yaml instead of metadata.yaml.
               mkdir -p "./${{ matrix.charm-dir }}"
-              # Create charmcraft.yaml file
               echo "name: $(echo ${{ github.repository }} | sed 's:.*/::')-test" > ./${{ matrix.charm-dir }}/charmcraft.yaml
               echo "links:" >> ./${{ matrix.charm-dir }}/charmcraft.yaml
               echo "  documentation: https://discourse.charmhub.io/t/charmed-mongodb-k8s-documentation/9731" >> ./${{ matrix.charm-dir }}/charmcraft.yaml

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Step info
         id: stepinfo
         run: |
-          echo "Step charm-dir" ${{ matrix.charm-dir }}
+          echo "Step charm-dir" -${{ matrix.charm-dir }}-
       # Each job has to have this configuration because secrets can be passed through the output of
       # another job
       - name: Generate discourse configuration
@@ -45,6 +45,7 @@ jobs:
       - name: Prepare stage
         id: prepare-stage
         run: |
+          set -x
           PYTHONPATH=$(pwd) python3 tests/e2e/migrate.py --action prepare --github-token  ${{ secrets.GITHUB_TOKEN }} '${{ steps.configuration.outputs.discourse }}'
           
           echo $(git log | head -n 1)

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -12,6 +12,12 @@ jobs:
     concurrency: e2e-tests
     permissions: write-all
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        charm-dir:
+          -
+          - charm
+        max-parallel: 1
     steps:
       # Each job has to have this configuration because secrets can be passed through the output of
       # another job

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -41,10 +41,6 @@ jobs:
       - name: Prepare stage
         id: prepare-stage
         run: |
-          set -x
-          git branch
-          git rev-parse HEAD
-          
           PYTHONPATH=$(pwd) python3 tests/e2e/migrate.py --charm-dir "./${{ matrix.charm-dir }}" --action prepare --github-token  ${{ secrets.GITHUB_TOKEN }} '${{ steps.configuration.outputs.discourse }}'
           git branch
           git rev-parse HEAD
@@ -58,7 +54,7 @@ jobs:
               git rm metadata.yaml
               git rm charmcraft.yaml
               git add charm/charmcraft.yaml
-              git commit -m " from metadata to charmcraft and charmdir"
+              git commit -m "Use charmcraft.yaml instead of metadata.yaml"
               git push
           fi
           
@@ -69,7 +65,6 @@ jobs:
           
           COMMIT_SHA=$(git log | head -n 1 | sed -En "s/commit\ //p")
           echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
-
 
       - name: Import Documentation
         id: import
@@ -127,7 +122,6 @@ jobs:
       - name: Create conflict
         id: create-conflict
         run: |
-          set -x
           PYTHONPATH=$(pwd) python3  tests/e2e/migrate.py --charm-dir "./${{ matrix.charm-dir }}"  --action create-conflict --github-token  ${{ secrets.GITHUB_TOKEN }} '${{ steps.configuration.outputs.discourse }}'
 
           git status

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -19,6 +19,10 @@ jobs:
           -
           - charm
     steps:
+      - name: Step info
+        id: stepinfo
+        run: |
+          echo "Step charm-dir" ${{ matrix.charm-dir }}
       # Each job has to have this configuration because secrets can be passed through the output of
       # another job
       - name: Generate discourse configuration
@@ -62,6 +66,10 @@ jobs:
           dry_run: true
           base_branch: "tests/base"
           commit_sha: ${{  steps.prepare-stage.outputs.commit_sha }}
+
+      - name: Tmate debugging session (gh-hosted)
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 30
 
       - name: Check creation
         run: |

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 1
       matrix:
         charm-dir:
-          # -
+          -
           - charm
     steps:
       - name: Step info
@@ -115,11 +115,6 @@ jobs:
           
           COMMIT_SHA=$(git log | head -n 1 | sed -En "s/commit\ //p")
           echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
-
-
-      # - name: Tmate debugging session (gh-hosted)
-      #   uses: mxschmitt/action-tmate@v3
-      #   timeout-minutes: 30
 
       - name: Release Pipeline Documentation
         id: release-import

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -49,7 +49,7 @@ jobs:
           git branch
           git rev-parse HEAD
           
-          PYTHONPATH=$(pwd) python3 tests/e2e/migrate.py --action prepare --github-token  ${{ secrets.GITHUB_TOKEN }} '${{ steps.configuration.outputs.discourse }}'
+          PYTHONPATH=$(pwd) python3 tests/e2e/migrate.py --charm-dir "./${{ matrix.charm-dir }}" --action prepare --github-token  ${{ secrets.GITHUB_TOKEN }} '${{ steps.configuration.outputs.discourse }}'
           git branch
           git rev-parse HEAD
 
@@ -93,7 +93,7 @@ jobs:
           echo '${{ steps.import.outputs.pr_link }}'
           echo '${{ steps.import.outputs.pr_action }}'
           echo $(git log | head -n 1)
-          PYTHONPATH=$(pwd) python3  tests/e2e/migrate.py  --action check-pull-request --github-token  ${{ secrets.GITHUB_TOKEN }} '${{ steps.configuration.outputs.discourse }}'
+          PYTHONPATH=$(pwd) python3  tests/e2e/migrate.py --charm-dir "./${{ matrix.charm-dir }}"  --action check-pull-request --github-token  ${{ secrets.GITHUB_TOKEN }} '${{ steps.configuration.outputs.discourse }}'
           echo $(git log | head -n 1)
           
           echo "Tags"
@@ -117,9 +117,9 @@ jobs:
           echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
 
 
-      - name: Tmate debugging session (gh-hosted)
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 30
+      # - name: Tmate debugging session (gh-hosted)
+      #   uses: mxschmitt/action-tmate@v3
+      #   timeout-minutes: 30
 
       - name: Release Pipeline Documentation
         id: release-import
@@ -163,7 +163,7 @@ jobs:
         run: |
           if [ ${{ steps.conflict.outcome }}  != "failure" ]; then exit 1; fi
           
-          PYTHONPATH=$(pwd) python3  tests/e2e/migrate.py  --action resolve-conflict --github-token  ${{ secrets.GITHUB_TOKEN }} '${{ steps.configuration.outputs.discourse }}'
+          PYTHONPATH=$(pwd) python3  tests/e2e/migrate.py --charm-dir "./${{ matrix.charm-dir }}"  --action resolve-conflict --github-token  ${{ secrets.GITHUB_TOKEN }} '${{ steps.configuration.outputs.discourse }}'
 
           COMMIT_SHA=$(git log | head -n 1 | sed -En "s/commit\ //p")
           echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
@@ -187,7 +187,7 @@ jobs:
           if [ ${{ steps.feature-check.outcome }}  != "success" ]; then exit 1; fi
           if [ ${{ steps.feature-check.outputs.pr_action }}  != "opened" ]; then exit 1; fi
           
-          PYTHONPATH=$(pwd) python3  tests/e2e/migrate.py  --action merge-feature --github-token  ${{ secrets.GITHUB_TOKEN }} '${{ steps.configuration.outputs.discourse }}'
+          PYTHONPATH=$(pwd) python3  tests/e2e/migrate.py --charm-dir "./${{ matrix.charm-dir }}"  --action merge-feature --github-token  ${{ secrets.GITHUB_TOKEN }} '${{ steps.configuration.outputs.discourse }}'
           COMMIT_SHA=$(git log | head -n 1 | sed -En "s/commit\ //p")
           echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
 
@@ -207,4 +207,4 @@ jobs:
         run: |
           if [ ${{ steps.release-feature.outputs.pr_action }}  != "closed" ]; then exit 1; fi
 
-          PYTHONPATH=$(pwd) python3  tests/e2e/migrate.py  --action cleanup --github-token  ${{ secrets.GITHUB_TOKEN }} '${{ steps.configuration.outputs.discourse }}'
+          PYTHONPATH=$(pwd) python3  tests/e2e/migrate.py --charm-dir "./${{ matrix.charm-dir }}"  --action cleanup --github-token  ${{ secrets.GITHUB_TOKEN }} '${{ steps.configuration.outputs.discourse }}'

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Import Documentation
         id: import
-        uses: canonical/discourse-gatekeeper@main
+        uses: canonical/discourse-gatekeeper@ISD-1620-NetBox-Build-all-missing-documentation-required-for-a-production-charm
         with:
           discourse_host: discourse.charmhub.io
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
@@ -87,7 +87,7 @@ jobs:
 
       - name: Release Pipeline Documentation
         id: release-import
-        uses: canonical/discourse-gatekeeper@main
+        uses: canonical/discourse-gatekeeper@ISD-1620-NetBox-Build-all-missing-documentation-required-for-a-production-charm
         with:
           discourse_host: discourse.charmhub.io
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
@@ -109,7 +109,7 @@ jobs:
       - name: Raise Conflict in PR
         id: conflict
         continue-on-error: true
-        uses: canonical/discourse-gatekeeper@main
+        uses: canonical/discourse-gatekeeper@ISD-1620-NetBox-Build-all-missing-documentation-required-for-a-production-charm
         with:
           discourse_host: discourse.charmhub.io
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
@@ -131,7 +131,7 @@ jobs:
 
       - name: Run Gatekeeper
         id: feature-check
-        uses: canonical/discourse-gatekeeper@main
+        uses: canonical/discourse-gatekeeper@ISD-1620-NetBox-Build-all-missing-documentation-required-for-a-production-charm
         with:
           discourse_host: discourse.charmhub.io
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
@@ -153,7 +153,7 @@ jobs:
 
       - name: Release Feature
         id: release-feature
-        uses: canonical/discourse-gatekeeper@main
+        uses: canonical/discourse-gatekeeper@ISD-1620-NetBox-Build-all-missing-documentation-required-for-a-production-charm
         with:
           discourse_host: discourse.charmhub.io
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 1
       matrix:
         charm-dir:
-          -
+          # -
           - charm
     steps:
       - name: Step info
@@ -47,8 +47,20 @@ jobs:
         run: |
           set -x
           git branch
+          git rev-parse HEAD
           
           PYTHONPATH=$(pwd) python3 tests/e2e/migrate.py --action prepare --github-token  ${{ secrets.GITHUB_TOKEN }} '${{ steps.configuration.outputs.discourse }}'
+          git branch
+          git rev-parse HEAD
+
+          if [ ! -d "./${{ matrix.charm-dir }}" ]; then
+              rm metadata.yaml
+              mkdir -p "${{ matrix.charm-dir }}"
+              # Create charmcraft.yaml file
+              echo "name: $(echo ${{ github.repository }} | sed 's:.*/::')-test" > "${{ matrix.charm-dir }}"/charmcraft.yaml
+              echo "links:" >> "${{ matrix.charm-dir }}"/charmcraft.yaml
+              echo "  documentation: https://discourse.charmhub.io/t/charmed-mongodb-k8s-documentation/9731" >> "${{ matrix.charm-dir }}"/charmcraft.yaml
+          fi
           
           echo $(git log | head -n 1)
           
@@ -58,13 +70,6 @@ jobs:
           COMMIT_SHA=$(git log | head -n 1 | sed -En "s/commit\ //p")
           echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
 
-          if [ ! -d "./${{ matrix.charm-dir }}" ]; then
-              mkdir -p "${{ matrix.charm-dir }}"
-              # Create charmcraft.yaml file
-              echo "name: $(echo ${{ github.repository }} | sed 's:.*/::')-test" > "${{ matrix.charm-dir }}"/charmcraft.yaml
-              echo "links:" >> "${{ matrix.charm-dir }}"/charmcraft.yaml
-              echo "  documentation: https://discourse.charmhub.io/t/charmed-mongodb-k8s-documentation/9731" >> "${{ matrix.charm-dir }}"/charmcraft.yaml
-          fi
 
       - name: Import Documentation
         id: import

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -46,6 +46,8 @@ jobs:
         id: prepare-stage
         run: |
           set -x
+          git branch
+          
           PYTHONPATH=$(pwd) python3 tests/e2e/migrate.py --action prepare --github-token  ${{ secrets.GITHUB_TOKEN }} '${{ steps.configuration.outputs.discourse }}'
           
           echo $(git log | head -n 1)

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 1
       matrix:
         charm-dir:
-          -
+          # -
           - charm
     steps:
       - name: Step info
@@ -135,7 +135,8 @@ jobs:
       - name: Create conflict
         id: create-conflict
         run: |
-          PYTHONPATH=$(pwd) python3  tests/e2e/migrate.py  --action create-conflict --github-token  ${{ secrets.GITHUB_TOKEN }} '${{ steps.configuration.outputs.discourse }}'
+          set -x
+          PYTHONPATH=$(pwd) python3  tests/e2e/migrate.py --charm-dir "./${{ matrix.charm-dir }}"  --action create-conflict --github-token  ${{ secrets.GITHUB_TOKEN }} '${{ steps.configuration.outputs.discourse }}'
 
           git status
 

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -56,7 +56,7 @@ jobs:
           COMMIT_SHA=$(git log | head -n 1 | sed -En "s/commit\ //p")
           echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
 
-          if [ ! -d "${{ matrix.charm-dir }}" ]; then
+          if [ ! -d "./${{ matrix.charm-dir }}" ]; then
               mkdir -p "${{ matrix.charm-dir }}"
               # Create charmcraft.yaml file
               echo "name: $(echo ${{ github.repository }} | sed 's:.*/::')-test" > "${{ matrix.charm-dir }}"/charmcraft.yaml

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -50,11 +50,11 @@ jobs:
           git rev-parse HEAD
 
           if [ ! -d "./${{ matrix.charm-dir }}" ]; then
-              mkdir -p "${{ matrix.charm-dir }}"
+              mkdir -p "./${{ matrix.charm-dir }}"
               # Create charmcraft.yaml file
-              echo "name: $(echo ${{ github.repository }} | sed 's:.*/::')-test" > "${{ matrix.charm-dir }}"/charmcraft.yaml
-              echo "links:" >> "${{ matrix.charm-dir }}"/charmcraft.yaml
-              echo "  documentation: https://discourse.charmhub.io/t/charmed-mongodb-k8s-documentation/9731" >> "${{ matrix.charm-dir }}"/charmcraft.yaml
+              echo "name: $(echo ${{ github.repository }} | sed 's:.*/::')-test" > ./${{ matrix.charm-dir }}/charmcraft.yaml
+              echo "links:" >> ./${{ matrix.charm-dir }}/charmcraft.yaml
+              echo "  documentation: https://discourse.charmhub.io/t/charmed-mongodb-k8s-documentation/9731" >> ./${{ matrix.charm-dir }}/charmcraft.yaml
               git rm metadata.yaml
               git rm charmcraft.yaml
               git add charm/charmcraft.yaml

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -13,11 +13,11 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-22.04
     strategy:
+      max-parallel: 1
       matrix:
         charm-dir:
           -
           - charm
-        max-parallel: 1
     steps:
       # Each job has to have this configuration because secrets can be passed through the output of
       # another job

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -54,12 +54,15 @@ jobs:
           git rev-parse HEAD
 
           if [ ! -d "./${{ matrix.charm-dir }}" ]; then
-              rm metadata.yaml
               mkdir -p "${{ matrix.charm-dir }}"
               # Create charmcraft.yaml file
               echo "name: $(echo ${{ github.repository }} | sed 's:.*/::')-test" > "${{ matrix.charm-dir }}"/charmcraft.yaml
               echo "links:" >> "${{ matrix.charm-dir }}"/charmcraft.yaml
               echo "  documentation: https://discourse.charmhub.io/t/charmed-mongodb-k8s-documentation/9731" >> "${{ matrix.charm-dir }}"/charmcraft.yaml
+              git rm metadata.yaml
+              git add charm/charmcraft.yaml
+              git commit -m " from metadata to charmcraft and charmdir"
+              git push
           fi
           
           echo $(git log | head -n 1)

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -66,10 +66,11 @@ jobs:
           dry_run: true
           base_branch: "tests/base"
           commit_sha: ${{  steps.prepare-stage.outputs.commit_sha }}
+          charm_dir:  ${{ matrix.charm-dir }}
 
-      - name: Tmate debugging session (gh-hosted)
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 30
+      # - name: Tmate debugging session (gh-hosted)
+      #   uses: mxschmitt/action-tmate@v3
+      #   timeout-minutes: 30
 
       - name: Check creation
         run: |
@@ -109,6 +110,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           base_branch: "tests/base"
           commit_sha: ${{  steps.merge-import.outputs.commit_sha }}
+          charm_dir:  ${{ matrix.charm-dir }}
 
       - name: Create conflict
         id: create-conflict
@@ -132,6 +134,7 @@ jobs:
           dry_run: true
           base_branch: "tests/base"
           commit_sha: ${{  steps.create-conflict.outputs.commit_sha }}
+          charm_dir:  ${{ matrix.charm-dir }}
 
       - name: Resolve conflict
         id: resolve-conflict
@@ -154,6 +157,7 @@ jobs:
           dry_run: true
           base_branch: "tests/base"
           commit_sha: ${{  steps.resolve-conflict.outputs.commit_sha }}
+          charm_dir:  ${{ matrix.charm-dir }}
 
       - name: Merge Feature Branch
         id: merge-feature
@@ -175,6 +179,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           base_branch: "tests/base"
           commit_sha: ${{  steps.merge-feature.outputs.commit_sha }}
+          charm_dir:  ${{ matrix.charm-dir }}
 
       - name: Cleanup
         run: |

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -60,6 +60,7 @@ jobs:
               echo "links:" >> "${{ matrix.charm-dir }}"/charmcraft.yaml
               echo "  documentation: https://discourse.charmhub.io/t/charmed-mongodb-k8s-documentation/9731" >> "${{ matrix.charm-dir }}"/charmcraft.yaml
               git rm metadata.yaml
+              git rm charmcraft.yaml
               git add charm/charmcraft.yaml
               git commit -m " from metadata to charmcraft and charmdir"
               git push

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -19,10 +19,6 @@ jobs:
           -
           - charm
     steps:
-      - name: Step info
-        id: stepinfo
-        run: |
-          echo "Step charm-dir" -${{ matrix.charm-dir }}-
       # Each job has to have this configuration because secrets can be passed through the output of
       # another job
       - name: Generate discourse configuration

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -55,6 +55,14 @@ jobs:
           COMMIT_SHA=$(git log | head -n 1 | sed -En "s/commit\ //p")
           echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
 
+          if [ ! -d "${{ matrix.charm-dir }}" ]; then
+              mkdir -p "${{ matrix.charm-dir }}"
+              # Create charmcraft.yaml file
+              echo "name: $(echo ${{ github.repository }} | sed 's:.*/::')-test" > "${{ matrix.charm-dir }}"/charmcraft.yaml
+              echo "links:" >> "${{ matrix.charm-dir }}"/charmcraft.yaml
+              echo "  documentation: https://discourse.charmhub.io/t/netbox-documentation-overview/13564" >> "${{ matrix.charm-dir }}"/charmcraft.yaml
+          fi
+
       - name: Import Documentation
         id: import
         uses: canonical/discourse-gatekeeper@ISD-1620-NetBox-Build-all-missing-documentation-required-for-a-production-charm
@@ -68,9 +76,9 @@ jobs:
           commit_sha: ${{  steps.prepare-stage.outputs.commit_sha }}
           charm_dir:  ${{ matrix.charm-dir }}
 
-      # - name: Tmate debugging session (gh-hosted)
-      #   uses: mxschmitt/action-tmate@v3
-      #   timeout-minutes: 30
+      - name: Tmate debugging session (gh-hosted)
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 30
 
       - name: Check creation
         run: |

--- a/.github/workflows/e2e_conflicts.yaml
+++ b/.github/workflows/e2e_conflicts.yaml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 1
       matrix:
         charm-dir:
-          # -
+          -
           - charm
     steps:
       - name: Step info

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -39,7 +39,7 @@ jobs:
         run: |
           set -x
           # Create metadata.yaml file
-          mkdir -p "${{ matrix.charm-dir }}"
+          [ -d "./${{ matrix.charm-dir }}" ] || mkdir "${{ matrix.charm-dir }}"
           echo "name: $(echo ${{ github.repository }} | sed 's:.*/::')-test" > ./${{ matrix.charm-dir }}/metadata.yaml
           
           # Create documentation index file

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -10,11 +10,11 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-22.04
     strategy:
+      max-parallel: 1
       matrix:
         charm-dir:
           -
           - charm
-        max-parallel: 1
     steps:
       - name: Step info
         id: stepinfo

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Draft self test
         id: dry-create
-        uses: canonical/discourse-gatekeeper@main
+        uses: canonical/discourse-gatekeeper@ISD-1620-NetBox-Build-all-missing-documentation-required-for-a-production-charm
         with:
           discourse_host: discourse.charmhub.io
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
@@ -99,7 +99,7 @@ jobs:
 
       - name: Create self test
         id: create
-        uses: canonical/discourse-gatekeeper@main
+        uses: canonical/discourse-gatekeeper@ISD-1620-NetBox-Build-all-missing-documentation-required-for-a-production-charm
         with:
           discourse_host: discourse.charmhub.io
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
@@ -136,7 +136,7 @@ jobs:
 
       - name: Update self test
         id: update
-        uses: canonical/discourse-gatekeeper@main
+        uses: canonical/discourse-gatekeeper@ISD-1620-NetBox-Build-all-missing-documentation-required-for-a-production-charm
         with:
           discourse_host: discourse.charmhub.io
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
@@ -169,7 +169,7 @@ jobs:
 
       - name: Close Merged PR
         id: update-closed
-        uses: canonical/discourse-gatekeeper@main
+        uses: canonical/discourse-gatekeeper@ISD-1620-NetBox-Build-all-missing-documentation-required-for-a-production-charm
         with:
           discourse_host: discourse.charmhub.io
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
@@ -193,7 +193,7 @@ jobs:
 
       - name: Delete topics disabled self test
         id: e2e-test-delete-topics
-        uses: canonical/discourse-gatekeeper@main
+        uses: canonical/discourse-gatekeeper@ISD-1620-NetBox-Build-all-missing-documentation-required-for-a-production-charm
         with:
           delete_topics: false
           discourse_host: discourse.charmhub.io
@@ -223,7 +223,7 @@ jobs:
 
       - name: Delete topics enabled self test
         id: e2e-test-delete
-        uses: canonical/discourse-gatekeeper@main
+        uses: canonical/discourse-gatekeeper@ISD-1620-NetBox-Build-all-missing-documentation-required-for-a-production-charm
         with:
           discourse_host: discourse.charmhub.io
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -126,7 +126,7 @@ jobs:
       - name: Add docs key to metadata
         id: add-docs-key
         run: |
-          echo "docs: ${{ steps.create.outputs.index_url }}" >> ./"${{ matrix.charm-dir }}"/charmcraft.yaml
+          echo "docs: ${{ steps.create.outputs.index_url }}" >> ./${{ matrix.charm-dir }}/metadata.yaml
           cat ./${{ matrix.charm-dir }}/metadata.yaml
           git status
           git add -u

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -59,6 +59,10 @@ jobs:
             "some uuid: $(uuidgen)" \
             > docs/alternate_doc.md
 
+      - name: Tmate debugging session (gh-hosted)
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 30
+
       - name: Prepare stage
         id: prepare-stage
         run: |

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -38,6 +38,7 @@ jobs:
       - name: Prepare for action to run
         run: |
           set -x
+          rm metadata.yaml
           # Create metadata.yaml file
           [ -d "./${{ matrix.charm-dir }}" ] || mkdir "${{ matrix.charm-dir }}"
           echo "name: $(echo ${{ github.repository }} | sed 's:.*/::')-test" > ./${{ matrix.charm-dir }}/metadata.yaml
@@ -92,6 +93,8 @@ jobs:
           dry_run: true
           base_branch: "tests/base"
           commit_sha: ${{  steps.prepare-stage.outputs.commit_sha }}
+          charm_dir:  ${{ matrix.charm-dir }}
+
       - name: Check dry creation
         run: |
           echo '${{ steps.dry-create.outputs.topics }}'
@@ -112,6 +115,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           base_branch: "tests/base"
           commit_sha: ${{  steps.prepare-stage.outputs.commit_sha }}
+          charm_dir:  ${{ matrix.charm-dir }}
+
       - name: Check creation
         run: |
           echo '${{ steps.create.outputs.index_url }}'
@@ -149,6 +154,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           base_branch: "tests/base"
           commit_sha: ${{  steps.add-docs-key.outputs.commit_sha }}
+          charm_dir:  ${{ matrix.charm-dir }}
 
       - name: Show pages
         run: |
@@ -182,7 +188,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           base_branch: "tests/base"
           commit_sha: ${{  steps.check-update.outputs.commit_sha }}
-
+          charm_dir:  ${{ matrix.charm-dir }}
 
       - name: Delete the alternate doc with delete_topics disabled
         id: alternate-doc-deleted
@@ -207,6 +213,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           base_branch: "tests/base"
           commit_sha: ${{  steps.alternate-doc-deleted.outputs.commit_sha }}
+          charm_dir:  ${{ matrix.charm-dir }}
 
       - name: Show pages
         run: echo '${{ steps.e2e-test-delete-topics.outputs.topics }}'
@@ -236,6 +243,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           base_branch: "tests/base"
           commit_sha: ${{  steps.doc-deleted.outputs.commit_sha }}
+          charm_dir:  ${{ matrix.charm-dir }}
+
       - name: Show pages
         run: echo '${{ steps.e2e-test-delete.outputs.topics }}'
       - name: Check delete topics enabled

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -9,7 +9,17 @@ jobs:
     concurrency: e2e-tests
     permissions: write-all
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        charm-dir:
+          -
+          - charm
+        max-parallel: 1
     steps:
+      - name: Step info
+        id: stepinfo
+        run: |
+          echo "Step charm-dir" ${{ matrix.charm-dir }}
       # Each job has to have this configuration because secrets can be passed through the output of
       # another job
       - name: Generate discourse configuration
@@ -58,10 +68,6 @@ jobs:
             "commit sha: ${{ github.sha }}, " \
             "some uuid: $(uuidgen)" \
             > docs/alternate_doc.md
-
-      - name: Tmate debugging session (gh-hosted)
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 30
 
       - name: Prepare stage
         id: prepare-stage

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -38,10 +38,11 @@ jobs:
       - name: Prepare for action to run
         run: |
           set -x
-          rm metadata.yaml
+          git rm metadata.yaml
           # Create metadata.yaml file
           [ -d "./${{ matrix.charm-dir }}" ] || mkdir "${{ matrix.charm-dir }}"
           echo "name: $(echo ${{ github.repository }} | sed 's:.*/::')-test" > ./${{ matrix.charm-dir }}/metadata.yaml
+          git add ./${{ matrix.charm-dir }}/metadata.yaml
           
           # Create documentation index file
           mkdir ./${{ matrix.charm-dir }}/docs

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -9,6 +9,12 @@ jobs:
     concurrency: e2e-tests
     permissions: write-all
     runs-on: ubuntu-22.04
+    strategy:
+      max-parallel: 1
+      matrix:
+        charm-dir:
+          -
+          - charm
     steps:
       # Each job has to have this configuration because secrets can be passed through the output of
       # another job
@@ -31,10 +37,13 @@ jobs:
 
       - name: Prepare for action to run
         run: |
+          set -x
           # Create metadata.yaml file
-          echo "name: $(echo ${{ github.repository }} | sed 's:.*/::')-test" > metadata.yaml
+          mkdir -p "${{ matrix.charm-dir }}"
+          echo "name: $(echo ${{ github.repository }} | sed 's:.*/::')-test" > ./${{ matrix.charm-dir }}/metadata.yaml
+          
           # Create documentation index file
-          mkdir docs
+          mkdir ./${{ matrix.charm-dir }}/docs
           # need some values in the content that change on every commit as discourse looks for file
           # similarity
           echo -e "# Charm Upload Automation Reconcile Test Index Title some uuid: $(uuidgen)\n" \
@@ -43,26 +52,26 @@ jobs:
             "branch: ${{ github.head_ref }}, " \
             "commit sha: ${{ github.sha }}, " \
             "some uuid: $(uuidgen)" \
-            > docs/index.md
+            > ./${{ matrix.charm-dir }}/docs/index.md
           echo -e "# Charm Upload Automation Reconcile Test Documentation Title some uuid: $(uuidgen)\n" \
             "placeholder documentation content for testing, " \
             "repository: ${{ github.repository }}, " \
             "branch: ${{ github.head_ref }}, " \
             "commit sha: ${{ github.sha }}, " \
             "some uuid: $(uuidgen)" \
-            > docs/doc.md
+            > ./${{ matrix.charm-dir }}/docs/doc.md
           echo -e "# Charm Upload Automation Reconcile Test Documentation Alternate Title some uuid: $(uuidgen)\n" \
             "placeholder documentation alternate content for testing, " \
             "repository: ${{ github.repository }}, " \
             "branch: ${{ github.head_ref }}, " \
             "commit sha: ${{ github.sha }}, " \
             "some uuid: $(uuidgen)" \
-            > docs/alternate_doc.md
+            > ./${{ matrix.charm-dir }}/docs/alternate_doc.md
 
       - name: Prepare stage
         id: prepare-stage
         run: |
-          PYTHONPATH=$(pwd) python3 tests/e2e/reconcile.py --action prepare --github-token  ${{ secrets.GITHUB_TOKEN }} '{}' '${{ steps.configuration.outputs.discourse }}'
+          PYTHONPATH=$(pwd) python3 tests/e2e/reconcile.py --charm-dir "./${{ matrix.charm-dir }}" --action prepare --github-token  ${{ secrets.GITHUB_TOKEN }} '{}' '${{ steps.configuration.outputs.discourse }}'
 
           echo $(git log | head -n 1)
 
@@ -87,7 +96,7 @@ jobs:
         run: |
           echo '${{ steps.dry-create.outputs.topics }}'
           echo $(git log | head -n 1)
-          PYTHONPATH=$(pwd) python3 tests/e2e/reconcile.py --action check-draft --github-token  ${{ secrets.GITHUB_TOKEN }} --action-kwargs '{"expected_url_results": []}' '${{ steps. dry-create.outputs.topics }}' '${{ steps.configuration.outputs.discourse }}'
+          PYTHONPATH=$(pwd) python3 tests/e2e/reconcile.py --charm-dir "./${{ matrix.charm-dir }}" --action check-draft --github-token  ${{ secrets.GITHUB_TOKEN }} --action-kwargs '{"expected_url_results": []}' '${{ steps. dry-create.outputs.topics }}' '${{ steps.configuration.outputs.discourse }}'
           echo $(git log | head -n 1)
 
           echo "Tags"
@@ -108,7 +117,7 @@ jobs:
           echo '${{ steps.create.outputs.index_url }}'
           echo '${{ steps.create.outputs.topics }}'
           echo $(git log | head -n 1)
-          PYTHONPATH=$(pwd) python3 tests/e2e/reconcile.py --action check-create --github-token  ${{ secrets.GITHUB_TOKEN }} --action-kwargs '{"expected_url_results": ["success", "success", "success"]}' '${{ steps.create.outputs.topics }}' '${{ steps.configuration.outputs.discourse }}'
+          PYTHONPATH=$(pwd) python3 tests/e2e/reconcile.py --charm-dir "./${{ matrix.charm-dir }}" --action check-create --github-token  ${{ secrets.GITHUB_TOKEN }} --action-kwargs '{"expected_url_results": ["success", "success", "success"]}' '${{ steps.create.outputs.topics }}' '${{ steps.configuration.outputs.discourse }}'
           echo $(git log | head -n 1)
 
           echo "Tags"
@@ -117,8 +126,8 @@ jobs:
       - name: Add docs key to metadata
         id: add-docs-key
         run: |
-          echo "docs: ${{ steps.create.outputs.index_url }}" >> metadata.yaml
-          cat metadata.yaml
+          echo "docs: ${{ steps.create.outputs.index_url }}" >> ./"${{ matrix.charm-dir }}"/charmcraft.yaml
+          cat ./${{ matrix.charm-dir }}/metadata.yaml
           git status
           git add -u
           git commit -m "Update metadata"
@@ -154,7 +163,7 @@ jobs:
           REPO='${{ github.repository }}'
 
           # This should also merge the PR, and the next action run should automatically close the PR
-          PYTHONPATH=$(pwd) python3 tests/e2e/reconcile.py --action check-update --github-token  ${{ secrets.GITHUB_TOKEN }} --action-kwargs "{\"expected_url_results\": [\"success\", \"success\", \"success\"]}" '${{ steps.create.outputs.topics }}' '${{ steps.configuration.outputs.discourse }}'
+          PYTHONPATH=$(pwd) python3 tests/e2e/reconcile.py --charm-dir "./${{ matrix.charm-dir }}" --action check-update --github-token  ${{ secrets.GITHUB_TOKEN }} --action-kwargs "{\"expected_url_results\": [\"success\", \"success\", \"success\"]}" '${{ steps.create.outputs.topics }}' '${{ steps.configuration.outputs.discourse }}'
 
           echo $(git log | head -n 1)
           COMMIT_SHA=$(git log | head -n 1 | sed -En "s/commit\ //p")
@@ -178,8 +187,8 @@ jobs:
       - name: Delete the alternate doc with delete_topics disabled
         id: alternate-doc-deleted
         run: |
-          rm docs/alternate-doc.md
-          sed -i '/alternate-doc/d' docs/index.md
+          rm ./${{ matrix.charm-dir }}/docs/alternate-doc.md
+          sed -i '/alternate-doc/d' ./${{ matrix.charm-dir }}/docs/index.md
           git add -u
           git commit -m "Delete docs/alternate_doc.md"
 
@@ -203,12 +212,12 @@ jobs:
         run: echo '${{ steps.e2e-test-delete-topics.outputs.topics }}'
       - name: Check delete topics disabled
         run: |
-          PYTHONPATH=$(pwd) python3 tests/e2e/reconcile.py --action check-delete-topics --github-token  ${{ secrets.GITHUB_TOKEN }} --action-kwargs '{"expected_url_results": ["success", "skip", "success"]}' '${{ steps.e2e-test-delete-topics.outputs.topics }}' '${{ steps.configuration.outputs.discourse }}'
+          PYTHONPATH=$(pwd) python3 tests/e2e/reconcile.py --charm-dir "./${{ matrix.charm-dir }}" --action check-delete-topics --github-token  ${{ secrets.GITHUB_TOKEN }} --action-kwargs '{"expected_url_results": ["success", "skip", "success"]}' '${{ steps.e2e-test-delete-topics.outputs.topics }}' '${{ steps.configuration.outputs.discourse }}'
       - name: Delete the doc with delete_topics enabled
         id: doc-deleted
         run: |
-          rm docs/doc.md
-          sed -i '/doc/d' docs/index.md
+          rm ./${{ matrix.charm-dir }}/docs/doc.md
+          sed -i '/doc/d' ./${{ matrix.charm-dir }}/docs/index.md
 
           git add -u
           git commit -m "Delete docs/alternate_doc.md"
@@ -231,10 +240,10 @@ jobs:
         run: echo '${{ steps.e2e-test-delete.outputs.topics }}'
       - name: Check delete topics enabled
         run: |
-          PYTHONPATH=$(pwd) python3 tests/e2e/reconcile.py --action check-delete --github-token  ${{ secrets.GITHUB_TOKEN }} --action-kwargs '{"expected_url_results": ["success", "success"]}' '${{ steps.e2e-test-delete.outputs.topics }}' '${{ steps.configuration.outputs.discourse }}'
+          PYTHONPATH=$(pwd) python3 tests/e2e/reconcile.py --charm-dir "./${{ matrix.charm-dir }}" --action check-delete --github-token  ${{ secrets.GITHUB_TOKEN }} --action-kwargs '{"expected_url_results": ["success", "success"]}' '${{ steps.e2e-test-delete.outputs.topics }}' '${{ steps.configuration.outputs.discourse }}'
       - name: Clean up
         if: always()
         run: |
           GITHUB_TOKEN='${{ secrets.GITHUB_TOKEN }}'
           REPO='${{ github.repository }}'
-          PYTHONPATH=$(pwd) python3 tests/e2e/reconcile.py --action cleanup --github-token  ${{ secrets.GITHUB_TOKEN }} --action-kwargs "{\"github_token\": \"$GITHUB_TOKEN\", \"repo\": \"$REPO\"}" '${{ steps.create.outputs.topics }}' '${{ steps.configuration.outputs.discourse }}'
+          PYTHONPATH=$(pwd) python3 tests/e2e/reconcile.py --charm-dir "./${{ matrix.charm-dir }}" --action cleanup --github-token  ${{ secrets.GITHUB_TOKEN }} --action-kwargs "{\"github_token\": \"$GITHUB_TOKEN\", \"repo\": \"$REPO\"}" '${{ steps.create.outputs.topics }}' '${{ steps.configuration.outputs.discourse }}'

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -2,7 +2,7 @@ name: E2E Pushing Tests
 
 on:
   workflow_dispatch:
-  # pull_request:
+  pull_request:
 
 jobs:
   e2e-tests-reconcile:

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -2,24 +2,14 @@ name: E2E Pushing Tests
 
 on:
   workflow_dispatch:
-  # pull_request:
+  pull_request:
 
 jobs:
   e2e-tests-reconcile:
     concurrency: e2e-tests
     permissions: write-all
     runs-on: ubuntu-22.04
-    strategy:
-      max-parallel: 1
-      matrix:
-        charm-dir:
-          -
-          - charm
     steps:
-      - name: Step info
-        id: stepinfo
-        run: |
-          echo "Step charm-dir" ${{ matrix.charm-dir }}
       # Each job has to have this configuration because secrets can be passed through the output of
       # another job
       - name: Generate discourse configuration

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -2,7 +2,7 @@ name: E2E Pushing Tests
 
 on:
   workflow_dispatch:
-  pull_request:
+  # pull_request:
 
 jobs:
   e2e-tests-reconcile:

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -37,7 +37,6 @@ jobs:
 
       - name: Prepare for action to run
         run: |
-          set -x
           git rm metadata.yaml
           # Create metadata.yaml file
           [ -d "./${{ matrix.charm-dir }}" ] || mkdir "${{ matrix.charm-dir }}"

--- a/.github/workflows/sync_discourse.yaml
+++ b/.github/workflows/sync_discourse.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Publish documentation
-        uses: canonical/discourse-gatekeeper@main
+        uses: canonical/discourse-gatekeeper@ISD-1620-NetBox-Build-all-missing-documentation-required-for-a-production-charm
 
         id: publishDocumentation
         with:

--- a/src/gatekeeper/__init__.py
+++ b/src/gatekeeper/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Library for uploading docs to charmhub."""
@@ -12,7 +12,7 @@ from . import navigation_table, reconcile
 from . import sort as sort_module
 from .action import DRY_RUN_NAVLINK_LINK, FAIL_NAVLINK_LINK
 from .clients import Clients
-from .constants import DOCUMENTATION_FOLDER_NAME, DOCUMENTATION_TAG
+from .constants import DOCUMENTATION_TAG
 from .download import recreate_docs
 from .exceptions import InputError, TaggingNotAllowedError
 from .repository import DEFAULT_BRANCH_NAME
@@ -50,7 +50,7 @@ def _get_reconcile_actions(
     Raises:
         InputError: if there are any problems with the contents index.
     """
-    docs_path = clients.repository.base_path / DOCUMENTATION_FOLDER_NAME
+    docs_path = clients.repository.docs_path
     path_infos = docs_directory.read(docs_path=docs_path)
 
     index_contents = index_module.get_contents(index_file=index.local, docs_path=docs_path)
@@ -105,7 +105,7 @@ def run_reconcile(clients: Clients, user_inputs: UserInputs) -> ReconcileOutputs
 
     index = index_module.get(
         metadata=clients.repository.metadata,
-        base_path=clients.repository.base_path,
+        docs_path=clients.repository.docs_path,
         server_client=clients.discourse,
     )
     server_content = (
@@ -133,7 +133,7 @@ def run_reconcile(clients: Clients, user_inputs: UserInputs) -> ReconcileOutputs
             index_url=index.server.url if index.server else "",
             topics=(
                 {
-                    f"{clients.discourse.absolute_url(row.navlink.link)}": ActionResult.SKIP
+                    clients.discourse.absolute_url(row.navlink.link): ActionResult.SKIP
                     for row in table_rows
                     if row.navlink.link
                 }
@@ -147,11 +147,7 @@ def run_reconcile(clients: Clients, user_inputs: UserInputs) -> ReconcileOutputs
         )
 
     actions, check_actions = tee(actions, 2)
-    problems = tuple(
-        check.conflicts(
-            actions=check_actions, repository=clients.repository, user_inputs=user_inputs
-        )
-    )
+    problems = tuple(check.conflicts(actions=check_actions))
     if problems:
         raise InputError(
             "One or more of the required actions could not be executed, see the log for details"
@@ -221,11 +217,19 @@ def run_migrate(clients: Clients, user_inputs: UserInputs) -> MigrateOutputs | N
 
     # Check difference with main
     changes = recreate_docs(clients, DOCUMENTATION_TAG)
+    # Check whether there are still changes after switching to the base branch
+    if changes:
+        changes = clients.repository.is_dirty(user_inputs.base_branch)
+
+        # Move the tag if there are no changes
+        if not changes:
+            with clients.repository.with_branch(user_inputs.base_branch) as repo:
+                main_hash = repo.current_commit
+            clients.repository.tag_commit(DOCUMENTATION_TAG, main_hash)
+
     if not changes:
         logging.info(
-            "No community contribution found in commit %s. Discourse is inline with %s",
-            user_inputs.commit_sha,
-            DOCUMENTATION_TAG,
+            "No community contribution found, discourse is inline with %s", DOCUMENTATION_TAG
         )
         # Given there are NO diffs compared to the base, if a PR is open, it should be closed
         if pull_request is not None:

--- a/src/gatekeeper/action.py
+++ b/src/gatekeeper/action.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Module for taking the required actions to match the server state with the local state."""

--- a/src/gatekeeper/check.py
+++ b/src/gatekeeper/check.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Module for running checks."""
@@ -10,9 +10,8 @@ from typing import NamedTuple, TypeGuard
 
 import requests
 
-from . import constants, content
+from . import content
 from .constants import DOCUMENTATION_TAG
-from .repository import Client
 from .types_ import (
     AnyAction,
     IndexContentsListItem,
@@ -20,7 +19,6 @@ from .types_ import (
     UpdateExternalRefAction,
     UpdateGroupAction,
     UpdatePageAction,
-    UserInputs,
 )
 
 
@@ -158,9 +156,7 @@ def _update_action_problem(action: UpdateAction) -> Problem | None:
     return problem
 
 
-def conflicts(
-    actions: Iterable[AnyAction], repository: Client, user_inputs: UserInputs
-) -> Iterator[Problem]:
+def conflicts(actions: Iterable[AnyAction]) -> Iterator[Problem]:
     """Check whether actions have any content conflicts.
 
     There are two types of conflicts. The first is where the local content is different to what is
@@ -176,8 +172,6 @@ def conflicts(
 
     Args:
         actions: The actions to check.
-        repository: Client for repository interactions.
-        user_inputs: Configuration from the user.
 
     Yields:
         A problem for each action with a conflict
@@ -196,12 +190,6 @@ def conflicts(
     if any_page_conflicts:
         return
 
-    commit_discourse_ahead_ok_tagged = repository.is_same_commit(
-        tag=constants.DISCOURSE_AHEAD_TAG, commit=user_inputs.commit_sha
-    )
-    if commit_discourse_ahead_ok_tagged:
-        return
-
     paths_with_diff = get_path_with_diffs(actions_logical_conflicts)
     if not paths_with_diff.base_local_diffs or not paths_with_diff.base_server_diffs:
         return
@@ -210,9 +198,7 @@ def conflicts(
         path=paths_with_diff.base_local_diffs[0],
         description=(
             "detected unmerged community contributions, these need to be resolved "
-            "before proceeding. If the differences are not conflicting, please apply the "
-            f"{constants.DISCOURSE_AHEAD_TAG} tag to commit {user_inputs.commit_sha} to "
-            "proceed. Paths with potentially unmerged community contributions: "
+            "before proceeding.  Paths with potentially unmerged community contributions: "
             f"{set(chain(paths_with_diff.base_local_diffs, paths_with_diff.base_server_diffs))}."
         ),
     )

--- a/src/gatekeeper/clients.py
+++ b/src/gatekeeper/clients.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Module for Client class."""
@@ -42,6 +42,8 @@ def get_clients(user_inputs: UserInputs, base_path: Path) -> Clients:
             api_key=user_inputs.discourse.api_key,
         ),
         repository=create_repository_client(
-            access_token=user_inputs.github_access_token, base_path=base_path
+            access_token=user_inputs.github_access_token,
+            base_path=base_path,
+            charm_dir=user_inputs.charm_dir,
         ),
     )

--- a/src/gatekeeper/commit.py
+++ b/src/gatekeeper/commit.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Module for handling interactions with git commit."""

--- a/src/gatekeeper/constants.py
+++ b/src/gatekeeper/constants.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Shared constants.
@@ -8,7 +8,6 @@ another module or to resolve circular imports.
 """
 DEFAULT_BRANCH = "main"
 DOCUMENTATION_TAG = "discourse-gatekeeper/base-content"
-DISCOURSE_AHEAD_TAG = "discourse-gatekeeper/discourse-ahead-ok"
 
 DOCUMENTATION_FOLDER_NAME = "docs"
 DOC_FILE_EXTENSION = ".md"

--- a/src/gatekeeper/content.py
+++ b/src/gatekeeper/content.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Module for checking conflicts using 3-way merge and create content based on a 3 way merge."""

--- a/src/gatekeeper/discourse.py
+++ b/src/gatekeeper/discourse.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Interface for Discourse interactions."""

--- a/src/gatekeeper/docs_directory.py
+++ b/src/gatekeeper/docs_directory.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Class for reading the docs directory."""
@@ -9,7 +9,7 @@ from itertools import count
 from pathlib import Path
 
 from . import types_
-from .constants import DOC_FILE_EXTENSION, DOCUMENTATION_FOLDER_NAME
+from .constants import DOC_FILE_EXTENSION
 
 
 def _get_directories_files(docs_path: Path) -> list[Path]:
@@ -152,13 +152,13 @@ def read(docs_path: Path) -> typing.Iterator[types_.PathInfo]:
     )
 
 
-def has_docs_directory(base_path: Path) -> bool:
+def has_docs_directory(docs_path: Path) -> bool:
     """Return existence of docs directory from base path.
 
     Args:
-        base_path: Base path of the repository to search the docs directory from
+        docs_path: Docs path of the repository where docs are
 
     Returns:
         True if documentation folder exists, False otherwise
     """
-    return (base_path / DOCUMENTATION_FOLDER_NAME).is_dir()
+    return docs_path.is_dir()

--- a/src/gatekeeper/download.py
+++ b/src/gatekeeper/download.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Library for downloading docs folder from charmhub."""
@@ -6,7 +6,6 @@
 import shutil
 
 from .clients import Clients
-from .constants import DOCUMENTATION_FOLDER_NAME
 from .index import contents_from_page
 from .index import get as get_index
 from .migration import run as migrate_contents
@@ -19,10 +18,10 @@ def _download_from_discourse(clients: Clients) -> None:
     Args:
         clients: Clients object
     """
-    base_path = clients.repository.base_path
+    docs_path = clients.repository.docs_path
     metadata = clients.repository.metadata
 
-    index = get_index(metadata=metadata, base_path=base_path, server_client=clients.discourse)
+    index = get_index(metadata=metadata, docs_path=docs_path, server_client=clients.discourse)
     server_content = (
         index.server.content if index.server is not None and index.server.content else ""
     )
@@ -32,7 +31,7 @@ def _download_from_discourse(clients: Clients) -> None:
         table_rows=table_rows,
         index_content=index_content,
         discourse=clients.discourse,
-        docs_path=base_path / DOCUMENTATION_FOLDER_NAME,
+        docs_path=docs_path,
     )
 
 
@@ -49,7 +48,7 @@ def recreate_docs(clients: Clients, base: str) -> bool:
     clients.repository.switch(base)
 
     # Remove docs folder and recreate content from discourse
-    docs_path = clients.repository.base_path / DOCUMENTATION_FOLDER_NAME
+    docs_path = clients.repository.docs_path
 
     if docs_path.exists():
         shutil.rmtree(docs_path)

--- a/src/gatekeeper/exceptions.py
+++ b/src/gatekeeper/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Exceptions for uploading docs to charmhub."""

--- a/src/gatekeeper/index.py
+++ b/src/gatekeeper/index.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Execute the uploading of documentation."""
@@ -10,12 +10,7 @@ from collections.abc import Iterable
 from enum import Enum, auto
 from pathlib import Path
 
-from .constants import (
-    DOC_FILE_EXTENSION,
-    DOCUMENTATION_FOLDER_NAME,
-    DOCUMENTATION_INDEX_FILENAME,
-    NAVIGATION_HEADING,
-)
+from .constants import DOC_FILE_EXTENSION, DOCUMENTATION_INDEX_FILENAME, NAVIGATION_HEADING
 from .discourse import Discourse
 from .exceptions import DiscourseError, InputError, ServerError
 from .types_ import Index, IndexContentsListItem, IndexFile, Metadata, Page
@@ -34,30 +29,30 @@ _HIDDEN_ITEM = _ITEM.replace(r"^", r"^<!-- ").replace(r"$", r" -->$")
 _HIDDEN_ITEM_PATTERN = re.compile(_HIDDEN_ITEM)
 
 
-def _read_docs_index(base_path: Path) -> str | None:
+def _read_docs_index(docs_path: Path) -> str | None:
     """Read the content of the index file.
 
     Args:
-        base_path: The starting path to look for the index content.
+        docs_path: The path to look for the index content.
 
     Returns:
         The content of the index file if it exists, otherwise return None.
 
     """
-    if not (docs_directory := base_path / DOCUMENTATION_FOLDER_NAME).is_dir():
+    if not docs_path.is_dir():
         return None
-    if not (index_file := docs_directory / DOCUMENTATION_INDEX_FILENAME).is_file():
+    if not (index_file := docs_path / DOCUMENTATION_INDEX_FILENAME).is_file():
         return None
 
     return index_file.read_text()
 
 
-def get(metadata: Metadata, base_path: Path, server_client: Discourse) -> Index:
+def get(metadata: Metadata, docs_path: Path, server_client: Discourse) -> Index:
     """Retrieve the local and server index information.
 
     Args:
         metadata: Information about the charm.
-        base_path: The base path to look for the metadata file in.
+        docs_path: The base path to look for the documentation.
         server_client: A client to the documentation server.
 
     Returns:
@@ -78,7 +73,7 @@ def get(metadata: Metadata, base_path: Path, server_client: Discourse) -> Index:
         server = None
 
     name_value = metadata.name
-    local_content = _read_docs_index(base_path=base_path)
+    local_content = _read_docs_index(docs_path=docs_path)
     local = IndexFile(
         title=f"{name_value.replace('-', ' ').title()} Documentation Overview",
         content=local_content,

--- a/src/gatekeeper/metadata.py
+++ b/src/gatekeeper/metadata.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Module for parsing metadata.yaml file."""
@@ -10,6 +10,10 @@ import yaml
 from . import types_
 from .exceptions import InputError
 
+CHARMCRAFT_FILENAME = "charmcraft.yaml"
+CHARMCRAFT_NAME_KEY = "name"
+CHARMCRAFT_LINKS_KEY = "links"
+CHARMCRAFT_LINKS_DOCS_KEY = "documentation"
 METADATA_DOCS_KEY = "docs"
 METADATA_FILENAME = "metadata.yaml"
 METADATA_NAME_KEY = "name"
@@ -18,20 +22,47 @@ METADATA_NAME_KEY = "name"
 def get(path: Path) -> types_.Metadata:
     """Check for and read the metadata.
 
+    The charm metadata can be in the file metadata.yaml or in charmcraft.yaml.
+    From charmcraft version 2.5, the information should be in charmcraft.yaml,
+    and the user should only modify that file. This function does not consider
+    the case in which the name is in one file and the doc link is in the other.
+
     Args:
-        path: The base path to look for the metadata file in.
+        path: The base path to look for the metadata files.
 
     Returns:
         The contents of the metadata file.
 
     Raises:
-        InputError: if the metadata file does not exists or is malformed.
+        InputError: if the metadata file does not exist or is malformed.
 
     """
     metadata_yaml = path / METADATA_FILENAME
-    if not metadata_yaml.is_file():
-        raise InputError(f"Could not find {METADATA_FILENAME} file, looked in folder: {path}")
+    if metadata_yaml.is_file():
+        return _parse_metadata_yaml(metadata_yaml)
 
+    charmcraft_yaml = path / CHARMCRAFT_FILENAME
+    if charmcraft_yaml.is_file():
+        return _parse_charmcraft_yaml(charmcraft_yaml)
+
+    raise InputError(
+        f"Could not find {METADATA_FILENAME} or {CHARMCRAFT_FILENAME} files"
+        f", looked in folder: {path}"
+    )
+
+
+def _parse_metadata_yaml(metadata_yaml: Path) -> types_.Metadata:
+    """Parse metadata file.
+
+    Args:
+        metadata_yaml: The file path the the metadata file.
+
+    Returns:
+        The contents of the metadata file.
+
+    Raises:
+        InputError: if the metadata file does not exist or are malformed.
+    """
     try:
         metadata = yaml.safe_load(metadata_yaml.read_text())
     except yaml.error.YAMLError as exc:
@@ -60,5 +91,57 @@ def get(path: Path) -> types_.Metadata:
         METADATA_DOCS_KEY in metadata and docs is None
     ):
         raise InputError(f"Invalid value for docs key: {docs}, expected a string value")
+
+    return types_.Metadata(name=name, docs=docs)
+
+
+def _parse_charmcraft_yaml(charmcraft_yaml: Path) -> types_.Metadata:
+    """Parse charmcraft file.
+
+    Args:
+        charmcraft_yaml: The file path the the charmcraft file.
+
+    Returns:
+        The contents of the charmcraft file.
+
+    Raises:
+        InputError: if the charmcraft file does not exist or are malformed.
+    """
+    try:
+        charmcraft = yaml.safe_load(charmcraft_yaml.read_text())
+    except yaml.error.YAMLError as exc:
+        raise InputError(
+            f"Malformed {CHARMCRAFT_FILENAME} file, read file: {charmcraft_yaml}"
+        ) from exc
+
+    if not charmcraft:
+        raise InputError(f"{CHARMCRAFT_FILENAME} file is empty, read file: {charmcraft_yaml}")
+    if not isinstance(charmcraft, dict):
+        raise InputError(
+            f"{CHARMCRAFT_FILENAME} file does not contain a mapping at the root, "
+            f"read file: {charmcraft_yaml}, content: {charmcraft!r}"
+        )
+
+    if CHARMCRAFT_NAME_KEY not in charmcraft:
+        raise InputError(
+            f"Could not find required key: {CHARMCRAFT_NAME_KEY}, "
+            f"read file: {charmcraft_yaml}, content: {charmcraft!r}"
+        )
+    if not isinstance(name := charmcraft[CHARMCRAFT_NAME_KEY], str):
+        raise InputError(f"Invalid value for name key: {name}, expected a string value")
+
+    docs = None
+    links = charmcraft.get(CHARMCRAFT_LINKS_KEY)
+    if links:
+        if not isinstance(links, dict):
+            raise InputError(
+                f"{CHARMCRAFT_FILENAME} invalid value for links {CHARMCRAFT_LINKS_KEY} key."
+            )
+
+        docs = links.get(CHARMCRAFT_LINKS_DOCS_KEY)
+        if not (isinstance(docs, str) or docs is None):
+            raise InputError(
+                f"Invalid value for documentation key: {docs}, expected a string value"
+            )
 
     return types_.Metadata(name=name, docs=docs)

--- a/src/gatekeeper/migration.py
+++ b/src/gatekeeper/migration.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Module for migrating remote documentation into local git repository."""
@@ -211,8 +211,9 @@ def _index_file_from_content(
         Index file document metadata.
     """
     contents_index = _migrate_navigation_table(rows=table_rows, discourse=discourse)
+    # Strip any whitespace around file contents to avoid building up more and more whitespace
     return types_.IndexDocumentMeta(
-        path=Path("index.md"), content=f"{content}\n\n{contents_index}"
+        path=Path("index.md"), content=f"{content.strip()}\n\n{contents_index}"
     )
 
 

--- a/src/gatekeeper/navigation_table.py
+++ b/src/gatekeeper/navigation_table.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Module for parsing and rendering a navigation table."""

--- a/src/gatekeeper/reconcile.py
+++ b/src/gatekeeper/reconcile.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Module for calculating required changes based on docs directory and navigation table."""
@@ -678,8 +678,9 @@ def index_page(
         The action to take for the index page.
     """
     table_contents = "\n".join(table_row.to_markdown(discourse.host) for table_row in table_rows)
+    # Strip any whitespace around file contents to avoid buildup of whitespace
     local_content = (
-        f"{index_module.get_content_for_server(index.local)}{NAVIGATION_TABLE_START}\n"
+        f"{index_module.get_content_for_server(index.local).strip()}\n{NAVIGATION_TABLE_START}\n"
         f"{table_contents}\n".strip()
     )
 

--- a/src/gatekeeper/repository.py
+++ b/src/gatekeeper/repository.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Module for handling interactions with git repository."""
@@ -168,6 +168,8 @@ class Client:  # pylint: disable=too-many-public-methods
 
     Attrs:
         base_path: The root directory of the repository.
+        base_charm_path: The directory of the repository where the charm is.
+        docs_path: The directory of the repository where the documentation is.
         metadata: Metadata object of the charm
         has_docs_directory: whether the repository has a docs directory
         current_branch: current git branch used in the repository
@@ -175,15 +177,19 @@ class Client:  # pylint: disable=too-many-public-methods
         branches: list of all branches
     """
 
-    def __init__(self, repository: Repo, github_repository: Repository) -> None:
+    def __init__(
+        self, repository: Repo, github_repository: Repository, charm_dir: str = ""
+    ) -> None:
         """Construct.
 
         Args:
             repository: Client for interacting with local git repository.
             github_repository: Client for interacting with remote github repository.
+            charm_dir: Relative directory where charm files are located.
         """
         self._git_repo = repository
         self._github_repo = github_repository
+        self._charm_dir = charm_dir
         self._configure_git_user()
 
     @cached_property
@@ -196,14 +202,32 @@ class Client:  # pylint: disable=too-many-public-methods
         return Path(self._git_repo.working_tree_dir or self._git_repo.common_dir)
 
     @property
+    def base_charm_path(self) -> Path:
+        """Return the Path of the charm in the repository.
+
+        Returns:
+            Path of the repository.
+        """
+        return self.base_path / self._charm_dir
+
+    @property
+    def docs_path(self) -> Path:
+        """Return the Path of the charm in the repository.
+
+        Returns:
+            Path of the repository.
+        """
+        return self.base_charm_path / DOCUMENTATION_FOLDER_NAME
+
+    @property
     def metadata(self) -> Metadata:
         """Return the Metadata object of the charm."""
-        return get_metadata(self.base_path)
+        return get_metadata(self.base_charm_path)
 
     @property
     def has_docs_directory(self) -> bool:
         """Return whether the repository has a docs directory."""
-        return has_docs_directory(self.base_path)
+        return has_docs_directory(self.docs_path)
 
     @property
     def current_branch(self) -> str:
@@ -248,7 +272,7 @@ class Client:  # pylint: disable=too-many-public-methods
         finally:
             self.switch(current_branch)
 
-    def get_summary(self, directory: str | None = DOCUMENTATION_FOLDER_NAME) -> DiffSummary:
+    def get_summary(self, directory: str | Path | None) -> DiffSummary:
         """Return a summary of the differences against the most recent commit.
 
         Args:
@@ -258,7 +282,8 @@ class Client:  # pylint: disable=too-many-public-methods
         Returns:
             DiffSummary object representing the summary of the differences.
         """
-        self._git_repo.git.add(directory or ".")
+        directory = str(directory) if directory else "."
+        self._git_repo.git.add(directory)
 
         return DiffSummary.from_raw_diff(
             self._git_repo.index.diff(None)
@@ -349,7 +374,7 @@ class Client:  # pylint: disable=too-many-public-methods
                     "Using stashed version.",
                     branch_name,
                 )
-                self._git_repo.git.checkout("--theirs", DOCUMENTATION_FOLDER_NAME)
+                self._git_repo.git.checkout("--theirs", str(self.docs_path))
             else:
                 raise RepositoryClientError(
                     f"Unexpected error when switching branch to {branch_name}. {exc=!r}"
@@ -404,9 +429,9 @@ class Client:  # pylint: disable=too-many-public-methods
     def update_branch(
         self,
         commit_msg: str,
+        directory: str | Path | None,
         push: bool = True,
         force: bool = False,
-        directory: str | None = DOCUMENTATION_FOLDER_NAME,
     ) -> "Client":
         """Update branch with a new commit.
 
@@ -423,6 +448,7 @@ class Client:  # pylint: disable=too-many-public-methods
         Returns:
             Repository client with the updated branch
         """
+        directory = str(directory) if directory else "."
         push_args = ["-u"]
         if force:
             push_args.append("-f")
@@ -433,7 +459,7 @@ class Client:  # pylint: disable=too-many-public-methods
             if push:
                 self._git_repo.git.push(*push_args)
 
-            self._git_repo.git.add("-A", directory or ".")
+            self._git_repo.git.add("-A", directory)
             self._git_repo.git.commit("-m", f"'{commit_msg}'")
             if push:
                 try:
@@ -535,9 +561,9 @@ class Client:  # pylint: disable=too-many-public-methods
         with self.create_branch(DEFAULT_BRANCH_NAME, base).with_branch(
             DEFAULT_BRANCH_NAME
         ) as repo:
-            msg = str(repo.get_summary())
+            msg = str(repo.get_summary(self.docs_path))
             logging.info("Creating new branch with new commit: %s", msg)
-            repo.update_branch(msg, force=True)
+            repo.update_branch(msg, directory=self.docs_path, force=True)
             pull_request = _create_github_pull_request(
                 self._github_repo, DEFAULT_BRANCH_NAME, base
             )
@@ -554,10 +580,10 @@ class Client:  # pylint: disable=too-many-public-methods
         with self.with_branch(branch) as repo:
             if repo.is_dirty():
                 repo.pull()
-                msg = str(repo.get_summary())
+                msg = str(repo.get_summary(self.docs_path))
                 logging.info("Summary: %s", msg)
                 logging.info("Updating PR with new commit: %s", msg)
-                repo.update_branch(msg)
+                repo.update_branch(msg, directory=self.docs_path)
 
     def is_dirty(self, branch_name: str | None = None) -> bool:
         """Check if repository path has any changes including new files.
@@ -719,12 +745,15 @@ def _get_repository_name_from_git_url(remote_url: str) -> str:
     return matched_repository.group(1)
 
 
-def create_repository_client(access_token: str | None, base_path: Path) -> Client:
+def create_repository_client(
+    access_token: str | None, base_path: Path, charm_dir: str = ""
+) -> Client:
     """Create a Github instance to handle communication with Github server.
 
     Args:
         access_token: Access token that has permissions to open a pull request.
         base_path: Path where local .git resides in.
+        charm_dir: Relative directory where the charm files are located.
 
     Raises:
         InputError: if invalid access token or invalid git remote URL is provided.
@@ -743,4 +772,4 @@ def create_repository_client(access_token: str | None, base_path: Path) -> Clien
     remote_url = local_repo.remote().url
     repository_fullname = _get_repository_name_from_git_url(remote_url=remote_url)
     remote_repo = github_client.get_repo(repository_fullname)
-    return Client(repository=local_repo, github_repository=remote_repo)
+    return Client(repository=local_repo, github_repository=remote_repo, charm_dir=charm_dir)

--- a/src/gatekeeper/sort.py
+++ b/src/gatekeeper/sort.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Sort items for publishing."""

--- a/src/gatekeeper/types_.py
+++ b/src/gatekeeper/types_.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Types for uploading docs to charmhub."""
@@ -44,7 +44,8 @@ class UserInputs(typing.NamedTuple):
         github_access_token: A Personal Access Token(PAT) or access token with repository access.
             Required in migration mode.
         commit_sha: The SHA of the commit the action is running on.
-        base_branch: The main branch against which the syncs act on
+        base_branch: The main branch against which the syncs act on.
+        charm_dir: Directory the charm is located in.
     """
 
     discourse: UserInputsDiscourse
@@ -53,6 +54,7 @@ class UserInputs(typing.NamedTuple):
     github_access_token: str | None
     commit_sha: str
     base_branch: str
+    charm_dir: str
 
 
 class Metadata(typing.NamedTuple):
@@ -388,6 +390,18 @@ class UpdatePageAction(_UpdateActionBase):
     """
 
     content_change: ContentChange
+
+    def __str__(self) -> str:
+        """Return a formatted representation of the dataclass.
+
+        Returns:
+            Formatted representation of the dataclass.
+        """
+        return (
+            f"class: {self.__class__}, level: {self.level}, path: {self.path}, "
+            f"navlink_change: {self.navlink_change}\n"
+            f"content_change:\n{self.content_change}"
+        )
 
 
 @dataclasses.dataclass

--- a/tests/e2e/common.py
+++ b/tests/e2e/common.py
@@ -12,7 +12,8 @@ from github import GithubException
 from src.gatekeeper.constants import DOCUMENTATION_TAG
 from src.gatekeeper.repository import DEFAULT_BRANCH_NAME, Client
 
-E2E_SETUP = "origin/tests/e2e"
+# E2E_SETUP = "origin/tests/e2e"
+E2E_SETUP = "origin/paas-app-charmer"
 E2E_BASE = "tests/base"
 E2E_BRANCH = "tests/feature"
 

--- a/tests/e2e/migrate.py
+++ b/tests/e2e/migrate.py
@@ -13,7 +13,7 @@ from typing import Tuple
 
 from src.gatekeeper import index as index_module
 from src.gatekeeper import navigation_table
-from src.gatekeeper.constants import DOCUMENTATION_FOLDER_NAME, DOCUMENTATION_TAG
+from src.gatekeeper.constants import DOCUMENTATION_TAG
 from src.gatekeeper.discourse import Discourse, create_discourse
 from src.gatekeeper.repository import (
     ACTIONS_PULL_REQUEST_TITLE,
@@ -191,7 +191,7 @@ def get_test_topic_file(repository: Client, discourse: Discourse) -> Tuple[Path,
 
     row = [row for row in table_rows if "t-overview" in row.path][0]
 
-    file_path = Path(".").joinpath(DOCUMENTATION_FOLDER_NAME, *row.path[:-1], f"{row.path[-1]}.md")
+    file_path = repository.docs_path.joinpath(*row.path[:-1], f"{row.path[-1]}.md")
 
     if not row.navlink.link:
         raise ValueError("Link in the row of the navigation table must be populated.")

--- a/tests/e2e/migrate.py
+++ b/tests/e2e/migrate.py
@@ -71,6 +71,7 @@ def main() -> None:
         "--action", help="Action to run", choices=tuple(action.value for action in Action)
     )
     parser.add_argument("--github-token", help="Github token to setup repository")
+    parser.add_argument("--charm-dir", help="Charm dir", default="")
     args = parser.parse_args()
     discourse_config = json.loads(args.discourse_config)
 

--- a/tests/e2e/migrate.py
+++ b/tests/e2e/migrate.py
@@ -76,7 +76,7 @@ def main() -> None:
     discourse_config = json.loads(args.discourse_config)
 
     discourse = create_discourse(**discourse_config)
-    repository = create_repository_client(args.github_token, Path.cwd())
+    repository = create_repository_client(args.github_token, Path.cwd(), charm_dir=args.charm_dir)
 
     match args.action:
         case Action.PREPARE.value:

--- a/tests/e2e/migrate.py
+++ b/tests/e2e/migrate.py
@@ -179,7 +179,7 @@ def get_test_topic_file(repository: Client, discourse: Discourse) -> Tuple[Path,
     """
     index = index_module.get(
         metadata=repository.metadata,
-        base_path=repository.base_path,
+        docs_path=repository.docs_path,
         server_client=discourse,
     )
 
@@ -217,7 +217,9 @@ def create_conflict(repository: Client, discourse: Discourse) -> bool:
 
     repository.create_branch(E2E_BRANCH, E2E_BASE).switch(E2E_BRANCH)
     file_path.write_text(source + "\n\n[E2E Test] Conflict in PR", encoding="utf-8")
-    repository.update_branch("Modification of documentation", force=True)
+    repository.update_branch(
+        "Modification of documentation", force=True, directory=repository.docs_path
+    )
 
     discourse.update_topic(
         url=topic_url,
@@ -246,7 +248,7 @@ def resolve_conflict(repository: Client, discourse: Discourse) -> bool:
     )
 
     file_path.write_text(source, encoding="utf-8")
-    repository.update_branch("Conflict resolution", force=True)
+    repository.update_branch("Conflict resolution", force=True, directory=repository.docs_path)
 
     discourse.update_topic(
         url=topic_url, content=source, edit_reason="Conflict resolution in Discourse"

--- a/tests/e2e/reconcile.py
+++ b/tests/e2e/reconcile.py
@@ -67,13 +67,14 @@ def main() -> None:
         "--action-kwargs", help="Arguments for the action as a JSON mapping", default="{}"
     )
     parser.add_argument("--github-token", help="Github token to setup repository")
+    parser.add_argument("--charm-dir", help="Charm dir", default="")
     args = parser.parse_args()
     urls_with_actions = json.loads(args.urls_with_actions)
     discourse_config = json.loads(args.discourse_config)
     action_kwargs = json.loads(args.action_kwargs)
 
     discourse = create_discourse(**discourse_config)
-    repository = create_repository_client(args.github_token, pathlib.Path.cwd())
+    repository = create_repository_client(args.github_token, pathlib.Path.cwd(), charm_dir=args.charm_dir)
 
     match args.action:
         case Action.PREPARE.value:

--- a/tests/e2e/reconcile.py
+++ b/tests/e2e/reconcile.py
@@ -74,7 +74,9 @@ def main() -> None:
     action_kwargs = json.loads(args.action_kwargs)
 
     discourse = create_discourse(**discourse_config)
-    repository = create_repository_client(args.github_token, pathlib.Path.cwd(), charm_dir=args.charm_dir)
+    repository = create_repository_client(
+        args.github_token, pathlib.Path.cwd(), charm_dir=args.charm_dir
+    )
 
     match args.action:
         case Action.PREPARE.value:


### PR DESCRIPTION
### Problem
<!-- What issue is this PR trying to solve? -->

Following https://github.com/canonical/discourse-gatekeeper/pull/238, the charm files (charmcraft.yaml, metadata.yaml and the docs directory) can be in a directory that is not in the repository base directory. This directory is specified by the github action input variable `charm_dir` in `discourse-gateway`. Besides, to get information from the charm, if the `metadata.yaml` file is not in the project, the `charmcraft.yaml` file will be used.

### Context
<!-- What is some specialized knowledge relevant to this project/technology -->

Using a customised directory instead of the base one and using only the `charmcraft.yaml` file are requirements for PAAS app charmer applications to work correctly. Besides, the use of `charmcraft.yaml` is the recommended way of specifying the name of the charm and the link to the doc for every project (see https://juju.is/docs/sdk/charmcraft-yaml).

### Solution
<!-- A summary of the solution addressing the above issue -->

See https://github.com/canonical/discourse-gatekeeper/pull/238.

### Testing
<!-- What steps need to be taken to test this PR? -->
A matrix strategy for workflows `e2e_conflicts.yaml` and `e2e_test.yaml` to test using the the base directory and the `charm` directory as charm_dir inputs.

In the workflow `e2e_conflicts.yaml` when using `charm` as `charm_dir`, the `charmcraft.yaml` file will be used instead of the `metadata.yaml` file.

### Release Notes
<!-- A digestable summary of the change in this PR -->
New input parameter `charm_dir` for `discourse-gatekeeper accepts`, that allows specifying where the charm files and directories are located it they are not in the base directory of the repository.
If the file `metadata.yaml` does not exist, the file `charmcraft.yaml` is used to get the charm name and the link to the documentation.
